### PR TITLE
Scrollable forms

### DIFF
--- a/src/tui/app/widgets/form.rs
+++ b/src/tui/app/widgets/form.rs
@@ -9,7 +9,6 @@ use ratatui::{
     text::Text,
     widgets::{Paragraph, Widget, Wrap},
 };
-use ratatui::style::Style;
 use strum::IntoEnumIterator;
 
 use super::{button::Button, input_box::InputBox};
@@ -496,7 +495,7 @@ impl<E: IntoEnumIterator + FormItemIndex + TryInto<FormWidget, Error = crate::Er
         }
 
         if full_area.height < form_height {
-            //form is overflowing draw a scrollbar
+            // form is overflowing draw a scrollbar
             CustomScrollBar {
                 cursor: scroll_cursor as usize,
                 total: form_height as usize,
@@ -521,15 +520,17 @@ impl<E: IntoEnumIterator + FormItemIndex + TryInto<FormWidget, Error = crate::Er
         page.x = full_area.x;
         page.height = full_area.height;
         page.y = full_area.y + current_page * page.height;
-        let item_overflow_top = (page.y).saturating_sub(scroll_cursor - scroll_cursor_item_height.div_ceil(2)) ;
-        let item_overflow_bottom = (scroll_cursor + scroll_cursor_item_height.div_ceil(2)).saturating_sub(page.y + page.height);
-        
+        let item_overflow_top =
+            (page.y).saturating_sub(scroll_cursor - scroll_cursor_item_height.div_ceil(2));
+        let item_overflow_bottom = (scroll_cursor + scroll_cursor_item_height.div_ceil(2))
+            .saturating_sub(page.y + page.height);
+
         page.y -= item_overflow_top;
         page.y += item_overflow_bottom;
 
         let visible_area = page.intersection(virtual_buf.area);
 
-        //Only show contents that are visible, copy contents from virtual buffer to the actual buffer
+        // Only show contents that are visible, copy contents from virtual buffer to the actual buffer
         for (src_row, dst_row) in visible_area.rows().zip(full_area.rows()) {
             for (src_col, dst_col) in src_row.columns().zip(dst_row.columns()) {
                 if let Some(dst) = buf.cell_mut((dst_col.x, dst_col.y)) {

--- a/src/tui/app/widgets/form.rs
+++ b/src/tui/app/widgets/form.rs
@@ -520,13 +520,11 @@ impl<E: IntoEnumIterator + FormItemIndex + TryInto<FormWidget, Error = crate::Er
         page.x = full_area.x;
         page.height = full_area.height;
         page.y = full_area.y + current_page * page.height;
-        let item_overflow_top =
-            (page.y).saturating_sub(scroll_cursor - scroll_cursor_item_height.div_ceil(2));
-        let item_overflow_bottom = (scroll_cursor + scroll_cursor_item_height.div_ceil(2))
-            .saturating_sub(page.y + page.height);
-
-        page.y -= item_overflow_top;
-        page.y += item_overflow_bottom;
+        let item_overflow_top = (page.y).saturating_sub(scroll_cursor - 1);
+        let item_overflow_bottom =
+            (scroll_cursor + scroll_cursor_item_height + 1).saturating_sub(page.y + page.height);
+        page.y = page.y.saturating_sub(item_overflow_top);
+        page.y = page.y.saturating_add(item_overflow_bottom);
 
         let visible_area = page.intersection(virtual_buf.area);
 

--- a/src/tui/app/widgets/form.rs
+++ b/src/tui/app/widgets/form.rs
@@ -481,7 +481,7 @@ impl<E: IntoEnumIterator + FormItemIndex + TryInto<FormWidget, Error = crate::Er
                         focus: self.form_focus && self.cursor == i,
                         label,
                     }
-                        .render(area, &mut virtual_buf, theme);
+                    .render(area, &mut virtual_buf, theme);
                     if self.form_focus && self.cursor == i {
                         scroll_cursor = area.y;
                     }
@@ -505,7 +505,7 @@ impl<E: IntoEnumIterator + FormItemIndex + TryInto<FormWidget, Error = crate::Er
                 cursor: scroll_cursor as usize,
                 total: form_height as usize,
             }
-                .render(scroll_area, buf);
+            .render(scroll_area, buf);
         }
 
         // Render popups at the end so they appear on the top


### PR DESCRIPTION
I added a virtual buffer for form widgets to render into first. This buffer acts as an off-screen layout area and prevents content overflow or rendering panics. After rendering, I copy only the visible portion (i.e. the intersection of the current page and the virtual buffer) into the actual display buffer. 